### PR TITLE
Fix quiz loading on GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains a simple quiz page and a small Node.js backend used to 
 ## Deploying
 
 - The frontend (`index.html`) can be deployed to GitHub Pages.
-- Host the backend (server.js) on any Node.js hosting platform (Render, Heroku, etc.).
-- In `index.html` set `BACKEND_URL` to the URL where the backend is deployed so that the page can fetch question files.
+- If you host the backend (`server.js`) on a Node.js platform (Render, Heroku, etc.), set `BACKEND_URL` in `index.html` to that URL so questions are requested from the server.
+- When deploying only to GitHub Pages without a backend, leave `BACKEND_URL` empty and the page will load the JSON files directly.
+- When deploying only to GitHub Pages, leave `BACKEND_URL` empty. The page expects the quiz JSON files to be located alongside `index.html` (e.g. `./PM04.json`).
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
         let QUESTIONS = [];
         let currentQuestionIndex = 0;
         let score = 0;
-        const TEST_FILES = ["PM04.json", "PM03.json"];
+        // Файлы с вопросами (относительные пути)
+        const TEST_FILES = ["./PM04.json", "./PM03.json"];
         let currentTestFileIndex = 0;
 
         // Функция для перемешивания массива
@@ -55,16 +56,23 @@
             }
         }
 
-        const BACKEND_URL = ""; // Замените на адрес своего сервера при развертывании
+        const BACKEND_URL = ""; // При использовании GitHub Pages оставьте пустым
 
-        // Загрузка вопросов с сервера
+        // Загрузка вопросов
         async function loadQuestions() {
             const file = TEST_FILES[currentTestFileIndex];
-            const url = `${BACKEND_URL}/questions?file=${encodeURIComponent(file)}`;
-            const response = await fetch(url);
-            QUESTIONS = await response.json();
-            QUESTIONS.forEach(q => shuffle(q.options)); // Перемешиваем варианты перед началом
-            showQuestion();
+            const url = BACKEND_URL
+                ? `${BACKEND_URL}/questions?file=${encodeURIComponent(file)}`
+                : file; // загружаем локальный файл при пустом BACKEND_URL
+
+            try {
+                const response = await fetch(url);
+                QUESTIONS = await response.json();
+                QUESTIONS.forEach(q => shuffle(q.options)); // Перемешиваем варианты перед началом
+                showQuestion();
+            } catch (err) {
+                console.error('Не удалось загрузить вопросы:', err);
+            }
         }
 
         // Показ текущего вопроса


### PR DESCRIPTION
## Summary
- use relative paths for quiz JSON files
- add error handling when loading quiz data
- document expected location of quiz files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849cf3c61288327979ee51bf4841d88