### PR TITLE
Add theme toggle and responsive styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ This repository contains a simple quiz page and a small Node.js backend used to 
    The application will be available at `http://localhost:3000`.
    The endpoint `/questions?file=PM04.json` will return the JSON file.
 
+You can also open `index.html` directly in a browser without running the
+server. Use the **Темная тема** button on the page to switch between light and
+dark modes. The chosen theme is saved in `localStorage` and applied on the next
+visit.
+
 ## Deploying
 
 - The frontend (`index.html`) can be deployed to GitHub Pages.
 - If you host the backend (`server.js`) on a Node.js platform (Render, Heroku, etc.), set `BACKEND_URL` in `index.html` to that URL so questions are requested from the server.
-- When deploying only to GitHub Pages without a backend, leave `BACKEND_URL` empty and the page will load the JSON files directly.
-- When deploying only to GitHub Pages, leave `BACKEND_URL` empty. The page expects the quiz JSON files to be located alongside `index.html` (e.g. `./PM04.json`).
+- When deploying only to GitHub Pages without a backend, leave `BACKEND_URL` empty and ensure the quiz JSON files are located alongside `index.html` (e.g. `./PM04.json`).
 

--- a/index.html
+++ b/index.html
@@ -4,25 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Тест</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        .question { font-size: 18px; margin-bottom: 10px; }
-        .options label { display: block; margin: 5px 0; position: relative; }
-        .options label.correct::after {
-            content: "✓";
-            color: green;
-            font-size: 18px;
-            margin-left: 10px;
-        }
-        .options label.incorrect::after {
-            content: "✖";
-            color: red;
-            font-size: 18px;
-            margin-left: 10px;
-        }
-        .button { margin-top: 20px; padding: 10px 20px; font-size: 16px; }
-        .number-input { margin-top: 20px; padding: 10px; font-size: 16px; width: 80px; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div id="app">
@@ -41,6 +23,7 @@
         <button class="button" id="switch-test-button">Сменить тест</button>
         <input type="number" class="number-input" id="goto-input" min="1" placeholder="№ вопроса">
         <button class="button" id="goto-button">Перейти</button>
+        <button class="button" id="theme-toggle">Темная тема</button>
     </div>
 
     <script>
@@ -50,6 +33,19 @@
         // Файлы с вопросами (относительные пути)
         const TEST_FILES = ["./PM04.json", "./PM03.json", "./PM05.json"];
         let currentTestFileIndex = 0;
+
+        const themeToggle = document.getElementById("theme-toggle");
+        const savedTheme = localStorage.getItem("theme");
+        if (savedTheme === "dark") {
+            document.body.classList.add("dark-theme");
+            themeToggle.textContent = "Светлая тема";
+        }
+
+        themeToggle.addEventListener("click", () => {
+            const isDark = document.body.classList.toggle("dark-theme");
+            localStorage.setItem("theme", isDark ? "dark" : "light");
+            themeToggle.textContent = isDark ? "Светлая тема" : "Темная тема";
+        });
 
         // Функция для перемешивания массива
         function shuffle(array) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,81 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --button-bg: #e0e0e0;
+  --button-text: #000000;
+}
+
+body.dark-theme {
+  --bg: #1e1e1e;
+  --text: #f5f5f5;
+  --button-bg: #333333;
+  --button-text: #f5f5f5;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+#app {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.question {
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.options label {
+  display: block;
+  margin: 5px 0;
+  position: relative;
+}
+.options label.correct::after {
+  content: "\2713";
+  color: green;
+  font-size: 18px;
+  margin-left: 10px;
+}
+.options label.incorrect::after {
+  content: "\2716";
+  color: red;
+  font-size: 18px;
+  margin-left: 10px;
+}
+
+.button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+  border-radius: 4px;
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: none;
+  cursor: pointer;
+}
+.button:hover {
+  opacity: 0.9;
+}
+
+.number-input {
+  margin-top: 20px;
+  padding: 10px;
+  font-size: 16px;
+  width: 80px;
+}
+
+@media (max-width: 480px) {
+  body {
+    margin: 10px;
+  }
+  .button {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}


### PR DESCRIPTION
## Summary
- move styles to a new `styles.css`
- add theme toggle button and persist preference
- implement dark theme variables and responsive layout
- document theme switcher in README
- clarify instructions for GitHub Pages

## Testing
- `npm test`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_684a56b09de0832797712dd66f670e63