### PR TITLE
Reorder UI controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
         <div id="question-section">
             <div class="question" id="question-text"></div>
             <div class="options" id="options-container"></div>
+            <div class="goto-container">
+                <input type="number" class="number-input" id="goto-input" min="1" placeholder="№ вопроса">
+                <button class="button" id="goto-button">Перейти</button>
+            </div>
             <button class="button" id="prev-button" style="display:none;">Назад</button>
             <button class="button" id="next-button">Далее</button>
             <button class="button" id="finish-button">Завершить тест</button>
@@ -21,8 +25,6 @@
         </div>
         <button class="button" id="restart-button" style="display:none;">Начать заново</button>
         <button class="button" id="switch-test-button">Сменить тест</button>
-        <input type="number" class="number-input" id="goto-input" min="1" placeholder="№ вопроса">
-        <button class="button" id="goto-button">Перейти</button>
         <button class="button" id="theme-toggle">Темная тема</button>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,18 @@ body {
   width: 80px;
 }
 
+.goto-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.goto-container .number-input,
+.goto-container .button {
+  margin-top: 0;
+}
+
 @media (max-width: 480px) {
   body {
     margin: 10px;


### PR DESCRIPTION
## Summary
- move question navigation input next to the answers
- keep "switch test" button after restart
- place theme toggle at the bottom
- add flex layout for navigation controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a5bb9ad0c8327af789c873ef6a3ec