### PR TITLE
Fix login page routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ This repository contains a simple quiz page and a small Node.js backend used to 
    The application will be available at `http://localhost:3000`.
    The endpoint `/questions?file=PM04.json` will return the JSON file.
 
-You can also open `index.html` directly in a browser without running the
-server. Use the **Темная тема** button on the page to switch between light and
-dark modes. The chosen theme is saved in `localStorage` and applied on the next
+The server now serves `login.html` at the root URL. Enter one of the allowed
+four-digit codes to access `index.html` and start the quiz. You can also open
+`index.html` directly without the login step if you do not need code
+protection.
+Use the **Темная тема** button on the page to switch between light and dark
+modes. The chosen theme is saved in `localStorage` and applied on the next
 visit.
 
 ## Deploying

--- a/login.html
+++ b/login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Вход</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        /* Center the form on the page */
+        #login-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 80vh;
+        }
+        #error {
+            color: red;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div id="login-container">
+        <input type="password" id="code-input" class="number-input" placeholder="Код" maxlength="4" autofocus>
+        <button id="login-button" class="button">Войти</button>
+        <div id="error" style="display:none;">Неверный код</div>
+    </div>
+
+    <script>
+        const allowedCodes = ["1489", "2288", "3826", "5252", "1230"];
+        const input = document.getElementById('code-input');
+        const error = document.getElementById('error');
+        document.getElementById('login-button').addEventListener('click', () => {
+            if (allowedCodes.includes(input.value.trim())) {
+                window.location.href = 'index.html';
+            } else {
+                error.style.display = 'block';
+            }
+        });
+        input.addEventListener('keyup', (e) => {
+            if (e.key === 'Enter') {
+                document.getElementById('login-button').click();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 
 const app = express();
 
+// Show login page by default
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'login.html'));
+});
+
 // Serve static files like index.html
 app.use(express.static(__dirname));
 


### PR DESCRIPTION
## Summary
- serve `login.html` as the default page
- note the change in README

## Testing
- `npm test`
- `npm start` then `curl -I http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_684c6ebeb5a88327a126919f1dc9da80