### PR TITLE
Improve authentication redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ This repository contains a simple quiz page and a small Node.js backend used to 
    The endpoint `/questions?file=PM04.json` will return the JSON file.
 
 The server now serves `login.html` at the root URL. Enter one of the allowed
-four-digit codes to access `index.html` and start the quiz. A successful login
-stores a flag in `localStorage`. If you try to open `index.html` directly
-without being authenticated, the page will redirect back to `login.html`.
+four-digit codes to access `index.html` and start the quiz. The valid codes are
+`1489`, `2288`, `3826`, `5252` and `1230`. A successful login stores a flag in
+`localStorage`. If you try to open `index.html` directly without being
+authenticated, the page will redirect back to `login.html`.
 Use the **Темная тема** button on the page to switch between light and dark
 modes. The chosen theme is saved in `localStorage` and applied on the next
 visit.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ This repository contains a simple quiz page and a small Node.js backend used to 
    The application will be available at `http://localhost:3000`.
    The endpoint `/questions?file=PM04.json` will return the JSON file.
 
-You can also open `index.html` directly in a browser without running the
-server. Use the **Темная тема** button on the page to switch between light and
-dark modes. The chosen theme is saved in `localStorage` and applied on the next
+The server now serves `login.html` at the root URL. Enter one of the allowed
+four-digit codes to access `index.html` and start the quiz. A successful login
+stores a flag in `localStorage`. If you try to open `index.html` directly
+without being authenticated, the page will redirect back to `login.html`.
+Use the **Темная тема** button on the page to switch between light and dark
+modes. The chosen theme is saved in `localStorage` and applied on the next
 visit.
 
 ## Deploying

--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <script>
+        if (localStorage.getItem('authenticated') !== 'true') {
+            window.location.href = 'login.html';
+        }
+    </script>
     <div id="app">
         <div id="question-section">
             <div class="question" id="question-text"></div>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Вход</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        /* Center the form on the page */
+        #login-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 80vh;
+        }
+        #error {
+            color: red;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div id="login-container">
+        <input type="password" id="code-input" class="number-input" placeholder="Код" maxlength="4" autofocus>
+        <button id="login-button" class="button">Войти</button>
+        <div id="error" style="display:none;">Неверный код</div>
+    </div>
+
+    <script>
+        const allowedCodes = ["1489", "2288", "3826", "5252", "1230"];
+        const input = document.getElementById('code-input');
+        const error = document.getElementById('error');
+        document.getElementById('login-button').addEventListener('click', () => {
+            if (allowedCodes.includes(input.value.trim())) {
+                localStorage.setItem('authenticated', 'true');
+                window.location.href = 'index.html';
+            } else {
+                error.style.display = 'block';
+            }
+        });
+        input.addEventListener('keyup', (e) => {
+            if (e.key === 'Enter') {
+                document.getElementById('login-button').click();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 
 const app = express();
 
+// Show login page by default
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'login.html'));
+});
+
 // Serve static files like index.html
 app.use(express.static(__dirname));
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const app = express();
 
 // Show login page by default
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, 'login.html'));
+  res.sendFile(path.join(__dirname, 'index.html'));
 });
 
 // Serve static files like index.html
@@ -14,10 +14,13 @@ app.use(express.static(__dirname));
 
 // Endpoint to return questions JSON
 app.get('/questions', (req, res) => {
+  res.set('Cache-Control', 'no-store'); // 🔧 Отключаем кэш для JSON
+
   const file = req.query.file;
   if (!file) {
     return res.status(400).json({ error: 'Missing file parameter' });
   }
+
   const filePath = path.join(__dirname, file);
   fs.readFile(filePath, 'utf8', (err, data) => {
     if (err) {


### PR DESCRIPTION
## Summary
- require login flag in `index.html`
- store login state in `localStorage` on successful entry
- document redirect behavior

## Testing
- `npm test`
- `npm start` then `curl -I http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_684c6ebeb5a88327a126919f1dc9da80